### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,4 @@
 
 ## Executing the ITs
 
-1. `oc create -f service.sso.yaml`
-2. Go in the OpenShift dashboard and wait for readiness
-3. `mvn fabric8:deploy -Popenshift`
-4. Go in the OpenShift dashboard and wait for readiness
-5. `mvn verify -Popenshift-it`
+Just execute following command: `mvn clean verify -Popenshift,openshift-it`


### PR DESCRIPTION
Vert.x SSO booster tests should handle all the deployment including starting the SSO server by itself.